### PR TITLE
add dependency libbsd

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -11,6 +11,7 @@ pkgbase = android-studio
 	depends = libxrender
 	depends = libxtst
 	depends = which
+	depends = libbsd
 	optdepends = gtk2: GTK+ look and feel
 	optdepends = libgl: emulator support
 	optdepends = ncurses5-compat-libs: native debugger support

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,6 +7,7 @@
 # Contributor: Philippe Hürlimann <p@hurlimann.org>
 # Contributor: Julian Raufelder <aur@raufelder.com>
 # Contributor: Dhina17 <dhinalogu@gmail.com>
+# Contributor: nato-re <alvare.renato@gmail.com>
 # Maintainer: Kordian Bruck <k@bruck.me>
 
 pkgname=android-studio
@@ -17,7 +18,7 @@ arch=('i686' 'x86_64')
 url="https://developer.android.com/"
 license=('APACHE')
 makedepends=()
-depends=('alsa-lib' 'freetype2' 'libxrender' 'libxtst' 'which')
+depends=('alsa-lib' 'freetype2' 'libxrender' 'libxtst' 'which' 'libbsd')
 optdepends=('gtk2: GTK+ look and feel'
             'libgl: emulator support'
             'ncurses5-compat-libs: native debugger support')


### PR DESCRIPTION
I had the same problem as Kaddate in [the comments on AUR package](https://aur.archlinux.org/packages/android-studio#comment-989477). I also never contributed before, so that's the changes I think would be necessary to add this dependency. I would really enjoy your feedback.