### PR TITLE
Update to 2025.3.1.8

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = android-studio
 	pkgdesc = The official Android IDE (Stable branch)
-	pkgver = 2025.2.3.9
+	pkgver = 2025.3.1.8
 	pkgrel = 1
 	url = https://developer.android.com/
 	arch = i686
@@ -15,10 +15,10 @@ pkgbase = android-studio
 	optdepends = libgl: emulator support
 	optdepends = ncurses5-compat-libs: native debugger support
 	options = !strip
-	source = https://dl.google.com/dl/android/studio/ide-zips/2025.2.3.9/android-studio-2025.2.3.9-linux.tar.gz
+	source = https://dl.google.com/dl/android/studio/ide-zips/2025.3.1.8/android-studio-panda1-patch1-linux.tar.gz
 	source = android-studio.desktop
 	source = license.html
-	sha256sums = 986ea6cacb36da723f2c8550cccd7d8cd3e8b8b7bb2446d3a8bf39bbaf91abc1
+	sha256sums = 678b8495f6368938927a8c8cc1a82484dd47e3640b77ec8b9983dc95722cda42
 	sha256sums = 73cd2dde1d0f99aaba5baad1e2b91c834edd5db3c817f6fb78868d102360d3c4
 	sha256sums = 9a7563f7fb88c9a83df6cee9731660dc73a039ab594747e9e774916275b2e23e
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,8 @@
 # Maintainer: Kordian Bruck <k@bruck.me>
 
 pkgname=android-studio
-pkgver=2025.2.3.9
+pkgver=2025.3.1.8
+_vername="panda1-patch1"
 pkgrel=1
 pkgdesc="The official Android IDE (Stable branch)"
 arch=('i686' 'x86_64')
@@ -22,10 +23,10 @@ optdepends=('gtk2: GTK+ look and feel'
             'libgl: emulator support'
             'ncurses5-compat-libs: native debugger support')
 options=('!strip')
-source=("https://dl.google.com/dl/android/studio/ide-zips/$pkgver/android-studio-$pkgver-linux.tar.gz"
+source=("https://dl.google.com/dl/android/studio/ide-zips/$pkgver/android-studio-$_vername-linux.tar.gz"
         "$pkgname.desktop"
         "license.html")
-sha256sums=('986ea6cacb36da723f2c8550cccd7d8cd3e8b8b7bb2446d3a8bf39bbaf91abc1'
+sha256sums=('678b8495f6368938927a8c8cc1a82484dd47e3640b77ec8b9983dc95722cda42'
             '73cd2dde1d0f99aaba5baad1e2b91c834edd5db3c817f6fb78868d102360d3c4'
             '9a7563f7fb88c9a83df6cee9731660dc73a039ab594747e9e774916275b2e23e')
 


### PR DESCRIPTION
The download URL has changed. The android studio zip file now uses the version name instead of numbers.
I added a _vername property to the PKGBUILD for this. 